### PR TITLE
simplify quotas - now time-based

### DIFF
--- a/apigateway_event.json
+++ b/apigateway_event.json
@@ -1,11 +1,10 @@
 {
   "body": "eyJ0ZXN0IjoiYm9keSJ9",
   "resource": "/{proxy+}",
-  "path0": "/list_keys",
-  "path1": "/delete_keys",
+  "path1": "/keys",
   "path": "/survey/1/interview/1/attachment/1",
-  "path3": "/survey/1/interview/1",
-  "path4": "/survey/1",
+  "path2": "/survey/1/interview/1",
+  "path3": "/survey/1",
   "httpMethod": "GET",
   "isBase64Encoded": true,
   "queryStringParameters": {

--- a/lambda/external_api.py
+++ b/lambda/external_api.py
@@ -1,8 +1,7 @@
 import json
 import os
 import logging
-import re
-from collections import namedtuple, defaultdict
+from collections import namedtuple
 
 import redis
 
@@ -12,24 +11,15 @@ Simulate an external RESTful API service with client throttling
 LOG = logging.getLogger()
 LOG.setLevel(logging.INFO)
 
-Response = namedtuple('Response', ['status_code', 'data', 'key', 'quota', 'message'])
+Response = namedtuple('Response', ['status_code', 'data', 'quota_exceeded', 'message'])
 
-# throttle thresholds
-thresholds = {
-    'global': {
-        'interval': 60,
-    },
-    'survey': {
-        'count': 20
-    },
-    'survey:interview': {
-        'count': 10
-    },
-    'survey:interview:attachment': {
-        'count': 5
-    }
-}
-
+# quota threshold counts - ttl in seconds
+quotas = dict(
+    second={'ttl': 1, 'quota': 2},
+    minute={'ttl': 60, 'quota': 60 * 2},
+    hour={'ttl': 60 * 60, 'quota': 60 * 60 * 2},
+    day={'ttl': 60 * 60 * 24, 'quota': 60 * 60 * 24 * 2}
+)
 
 # match incoming path to ascertain resource
 pattern = r'/([a-zA-Z]+)'
@@ -46,18 +36,75 @@ def handler(event, context):
     main entry point
     event contains dict from api gateway request
     """
-    LOG.info('request: {}'.format(json.dumps(event)))
+    # LOG.info('request: {}'.format(json.dumps(event)))
     LOG.info('redis address: {}'.format(os.environ['REDIS_ADDRESS']))
 
     api_key = 'none'  # using empty api_key for now
     path = event['path']
-    httpMethod = event['httpMethod']
-    LOG.info(f"path='{path}', method={httpMethod}")
+    http_method = event['httpMethod']
+    LOG.info(f"path='{path}', method={http_method}")
 
-    if httpMethod != 'GET':
+    if http_method == 'GET':
+        if path.startswith('/survey'):
+            response = get_response(api_key)
+            LOG.info(f'response={response}')
+
+            body = {
+                'data': response.data,
+                'quota_exceeded': response.quota_exceeded
+            }
+
+            if response.quota_exceeded:
+                body['status_code'] = 429
+                body['message'] = response.message
+            else:
+                body['status_code'] = 200
+                body['message'] = 'Hello, CDK!  You have hit {}\n'.format(path),
+        elif path == '/keys':
+            key_data = {'keys': []}
+            for key in sorted(r.keys()):
+                key_data['keys'].append({
+                    'name': key,
+                    'value': r.get(key),
+                    'ttl': r.ttl(key)
+                })
+
+            return {
+                'statusCode': 200,
+                'headers': {
+                    'Content-Type': 'application/json'
+                },
+                'body': json.dumps(key_data)
+            }
+        else:
+            body = {
+                'status_code': 400,
+                'message': f"'{path}' is not a valid resource.  Try /survey/1/interview/1/attachment/1 or /list_keys"
+            }
+
+        return {
+            'statusCode': body['status_code'],
+            'headers': {
+                'Content-Type': 'application/json'
+            },
+            'body': json.dumps(body)
+        }
+    elif http_method == 'DELETE':
+        if path == '/keys':
+            for key in r.keys('quota:*'):
+                r.delete(key)
+                LOG.info('deleted key {}'.format(key))
+                return {
+                    'statusCode': 200,
+                    'headers': {
+                        'Content-Type': 'application/json'
+                    },
+                    'body': 'cache cleared of keys matching survey:*'
+                }
+    else:
         response = {
             'status_code': 405,
-            'message': f"HTTP method '{httpMethod}' is not a supported method.  Try GET"
+            'message': f"HTTP method '{http_method}' is not a supported method.  Try GET"
         }
         return {
             'statusCode': 405,
@@ -67,188 +114,87 @@ def handler(event, context):
             'body': json.dumps(response)
         }
 
-    if path.startswith('/survey'):
-        response = get_response(location=path, api_key=api_key)
-        LOG.info(f'response={response}')
-        LOG.info(f'remaining quota of {response.key}={response.quota}')
 
-        body = {
-            'data': response.data,
-            'quota': response.quota
-        }
-
-        if response.quota > 0:
-            body['status_code'] = 200
-            body['message'] = 'Hello, CDK!  You have hit {}\n'.format(path),
-        else:
-            body['status_code'] = 429
-            body['message'] = response.message
-    elif path == '/keys':
-        key_data = {'keys': []}
-        for key in sorted(r.keys()):
-            key_data['keys'].append({
-                'name': key,
-                'value': r.get(key),
-                'ttl': r.ttl(key)
-            })
-
-        return {
-            'statusCode': 200,
-            'headers': {
-                'Content-Type': 'application/json'
-            },
-            'body': json.dumps(key_data)
-        }
-    elif path == '/clear_cache':
-        for key in r.keys('survey:*'):
-            r.delete(key)
-            LOG.info('deleted key {}'.format(key))
-            return {
-                'statusCode': 200,
-                'headers': {
-                    'Content-Type': 'application/json'
-                },
-                'body': 'cache cleared of keys matching survey:*'
-            }
-    else:
-        body = {
-            'status_code': 400,
-            'message': f"'{path}' is not a valid resource.  Try /survey/1/interview/1/attachment/1 or /list_keys"
-        }
-
-    return {
-        'statusCode': body['status_code'],
-        'headers': {
-            'Content-Type': 'application/json'
-        },
-        'body': json.dumps(body)
-    }
-
-
-def get_response(location: str, api_key: str) -> namedtuple:
+def get_response(api_key: str) -> namedtuple:
     """
     get response data
-    :param location: request path
     :param api_key: api_key or ''
     :return:
     """
-    key = make_key(location, api_key)
-    exceeded, location = quota_exceeded(key)
+    exceeded, interval = quota_exceeded(api_key)
 
     if exceeded:
-        response = Response(status_code=200, data={'data': 'something'}, key=key, quota=0,
-                            message=f'quota exceeded at {location}')
+        response = Response(status_code=200, data={}, quota_exceeded=exceeded,
+                            message=f'{interval} quota exceeded')
     else:
-        new_key_value = decrement_key(key)
-        response = Response(status_code=200, data={'data': 'something'}, key=key, quota=new_key_value, message='ok')
+        response = Response(status_code=200, data={'data': 'something'}, quota_exceeded=exceeded, message='ok')
+        decrement_keys(api_key)
 
     return response
 
 
-def quota_exceeded(key:str)-> 'tuple':
+def quota_exceeded(api_key: str) -> tuple:
     """
-    check quota of key and parent paths
-    :param key:
+    check quota of key for each time interval
+    :param api_key:
     :return: True if quota exceeded, otherwise False
     """
-    resources, api_key = list(key.split(':')[:-1]), key.split(':')[-1:][0]
+    expired_interval = None
 
-    for end in range(len(resources) - 1, 0, -1):
-        parent_key = ':'.join([*resources[:-end], api_key])
-        parent_quota = key_value(parent_key)
-        if parent_quota is not None and int(parent_quota) == 0:
-            return True, parent_key
+    for interval in quotas.keys():
+        interval_key = ':'.join([api_key, interval])
+        if key_value(interval_key) <= 0:
+            expired_interval = interval
 
-    quota = key_value(key)
-    if quota is not None and int(r.get(key)) <= 0:
-        return True, key
-
-    return False, key
+    return expired_interval is not None, expired_interval
 
 
-def set_expiry_and_quota(key: str) -> None:
-    """
-
-    :param key: key string
-    :return: nothing
-    """
-    expiration = thresholds['global']['interval']
-    quota = key_quota(key)
-    # could use a pipeline here to make atomic
-    pipeline = r.pipeline().set(key, quota).expire(key, expiration)
-    pipeline.execute()
-    # r.set(key, quota)
-    # r.expire(key, expiration)  # set ttl
-    LOG.info(f'set key {key} value to {quota} and expiration {expiration}')
-
-
-def key_value(key: str)-> int:
+def key_value(key: str) -> int:
     """
     get value of key
     if key doesn't exist
-      create it with threshold value
-      set expiration
+      create it with threshold value and expiration
     :param key: the key
     :return: value of key
     """
     if not r.exists(key):
-        LOG.info(f'key {key} does not exist - setting value and expiration')
         set_expiry_and_quota(key)
     else:
         if r.ttl(key) == -1:
-            LOG.info(f'key {key} exists but has no expiry - setting value and expiration')
+            LOG.info(f'key {key} exists but has no expiry - setting new value and expiration')
             set_expiry_and_quota(key)
 
-    return r.get(key)
+    return int(r.get(key))
 
 
-def make_key(path: str, api_key: str)-> str:
+def set_expiry_and_quota(key: str) -> None:
     """
-    make key from path and api_key
-    :param path: request path
-    :param api_key: api_key or ''
-    :return: storage key
+    Set quota value and expiration on key atomically
+    :param key: key string
+    :return: nothing
     """
-    path_parts = re.findall(pattern, path)
-    key = ':'.join([*path_parts, api_key])
-    return key
+    interval = key.split(':')[-1:][0]
+    quota = quotas[interval]
+
+    # using a pipeline here to make atomic
+    pipeline = r.pipeline().set(key, quota['quota']).expire(key, quota['ttl'])
+    pipeline.execute()
+    LOG.info(f"set key {key} quota={quota['quota']} and ttl={quota['ttl']}")
 
 
-def key_quota(key: str)-> int:
-    """
-    get quota for key
-    :param key: key name
-    :return: int showing quota count or -1 if not defined
-    """
-    resource_key = ':'.join(key.split(':')[:-1])  # strip off api_key
-    try:
-        quota = thresholds[resource_key]['count']
-    except KeyError as e:
-        LOG.info('resource_key {} not found in thresholds'.format(resource_key))
-        quota = -1
-
-    return quota
-
-
-def decrement_key(key: str) -> int:
+def decrement_keys(api_key: str) -> None:
     """
     walk down resource path composite keys
       if key not exist, set to threshold count and set expire
       decrement resource count key
-    :param key: item key
+    :param api_key: item key
     :return: key value after decrement of last key
     """
-    # decrement parent keys
-    resources, api_key = list(key.split(':')[:-1]), key.split(':')[-1:][0]
-    for end in range(len(resources) - 1, 0, -1):
-        parent_key = ':'.join([*resources[:-end], api_key])
-        if r.exists(parent_key):
-            r.decr(parent_key)
+    # decrement keys
+    for interval in quotas.keys():
+        interval_key = ':'.join([api_key, interval])
+        if r.exists(interval_key):
+            r.decr(interval_key)
         else:
-            key_value(parent_key)
-            r.decr(parent_key)
-
-    # decrement leaf key
-    value = key_value(key)
-    r.decr(key)
-    return int(value)
+            key_value(interval_key)
+            r.decr(interval_key)


### PR DESCRIPTION
Change quotas to multi-level time based and update README

I mistakenly made quotas hierarchically based on the resource path but that's not how APIs i've seen behave.
They usually have a hierarchy of time-based quotas.
e.g. 20/second, 300/minute, 1000/hour, 10000/day or something along those lines.